### PR TITLE
Add: GeneralResponse obj with builder pattern, GlobalErrorHandler

### DIFF
--- a/NeighSecure-API/src/main/java/com/example/neighsecureapi/domain/dtos/GeneralResponse.java
+++ b/NeighSecure-API/src/main/java/com/example/neighsecureapi/domain/dtos/GeneralResponse.java
@@ -1,0 +1,84 @@
+package com.example.neighsecureapi.domain.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class GeneralResponse {
+    String message;
+    Object data;
+
+    private GeneralResponse(Builder builder) {
+        this.message = builder.message;
+        this.data = builder.data;
+    }
+
+    public static class Builder {
+        private String message;
+        private Object data;
+
+        public Builder message(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public Builder data(Object data) {
+            this.data = data;
+            return this;
+        }
+
+        public GeneralResponse build() {
+            return new GeneralResponse(this);
+        }
+    }
+
+    public static ResponseEntity<GeneralResponse> getResponse(HttpStatus status, String message, Object data){
+        return new ResponseEntity<>(
+                new Builder().message(message).data(data).build(),
+                status
+        );
+    }
+
+    public static ResponseEntity<GeneralResponse> getResponse(HttpStatus status, String message){
+        return new ResponseEntity<>(
+                new Builder().message(message).build(),
+                status
+        );
+    }
+
+    public static ResponseEntity<GeneralResponse> getResponse(HttpStatus status, Object data){
+        return new ResponseEntity<>(
+                new Builder().message(status.getReasonPhrase()).data(data).build(),
+                status
+        );
+    }
+
+    public static ResponseEntity<GeneralResponse> getResponse(String message, Object data){
+        return new ResponseEntity<>(
+                new Builder().message(message).data(data).build(),
+                HttpStatus.OK
+        );
+    }
+
+    public static ResponseEntity<GeneralResponse> getResponse(String message){
+        return new ResponseEntity<>(
+                new Builder().message(message).build(),
+                HttpStatus.OK
+        );
+    }
+
+    public static ResponseEntity<GeneralResponse> getResponse(HttpStatus status){
+        return new ResponseEntity<>(
+                new Builder().message(status.getReasonPhrase()).build(),
+                status
+        );
+    }
+
+    // agregar nuevos metodos de ser necesario
+
+}

--- a/NeighSecure-API/src/main/java/com/example/neighsecureapi/handlers/GlobalErrorHandler.java
+++ b/NeighSecure-API/src/main/java/com/example/neighsecureapi/handlers/GlobalErrorHandler.java
@@ -1,6 +1,58 @@
 package com.example.neighsecureapi.handlers;
 
+
+import com.example.neighsecureapi.domain.dtos.GeneralResponse;
+import com.example.neighsecureapi.utils.ErrorsTools;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+@ControllerAdvice
+@Slf4j
 public class GlobalErrorHandler {
 
-    //TODO: agregar patron builder usando ErrorsTools
+    private final ErrorsTools errorsTools;
+
+    public GlobalErrorHandler(ErrorsTools errorsTools) {
+        this.errorsTools = errorsTools;
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<GeneralResponse> GeneralHandler(Exception e){
+        //log.error("Error: ", e);
+        return GeneralResponse.getResponse(
+                HttpStatus.INTERNAL_SERVER_ERROR
+        );
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<GeneralResponse> ResourceNotFoundHandler(NoResourceFoundException e){
+        //log.error("Error: ", e);
+        return GeneralResponse.getResponse(
+                HttpStatus.NOT_FOUND
+        );
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<GeneralResponse> BadRequestHandler(MethodArgumentNotValidException ex){
+        //log.error("Error: ", ex);
+        return GeneralResponse.getResponse(
+                HttpStatus.BAD_REQUEST,
+                errorsTools.mapErrors(ex.getBindingResult().getFieldErrors())
+        );
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<GeneralResponse> IllegalArgumentHandler(IllegalArgumentException e){
+        //log.error("Error: ", e);
+        return GeneralResponse.getResponse(
+                HttpStatus.BAD_REQUEST,
+                e.getMessage()
+        );
+    }
 }


### PR DESCRIPTION
Se agrego la clase GeneralResponse para utilizarse en los controladores aplicando el patrón de diseño builder, también el handler de errores globales para manejar las excepciones base que puedan ocurrir, sujeto a adiciones a futuro